### PR TITLE
Feature/explorer

### DIFF
--- a/components/ExplorerPanel.tsx
+++ b/components/ExplorerPanel.tsx
@@ -1,0 +1,526 @@
+"use client";
+
+import { useState, useMemo, useRef, useEffect, useCallback } from "react";
+import type { GraphNode } from "@/lib/types";
+import { READING_PATHS } from "@/lib/paths";
+
+type Mode = "browse" | "paths";
+
+const MIN_WIDTH = 272;
+const MAX_WIDTH = 600;
+const DEFAULT_WIDTH = 480;
+const STORAGE_KEY = "apeiron-explorer-width";
+
+function loadWidth(): number {
+  if (typeof window === "undefined") return DEFAULT_WIDTH;
+  try {
+    const v = localStorage.getItem(STORAGE_KEY);
+    if (v) {
+      const n = Number(v);
+      if (n >= MIN_WIDTH && n <= MAX_WIDTH) return n;
+    }
+  } catch {}
+  return DEFAULT_WIDTH;
+}
+
+interface Props {
+  nodes: GraphNode[];
+  open: boolean;
+  onClose: () => void;
+  onNodeSelect: (nodeId: string) => void;
+}
+
+export default function ExplorerPanel({
+  nodes,
+  open,
+  onClose,
+  onNodeSelect,
+}: Props) {
+  const [mode, setMode] = useState<Mode>("paths");
+  const [query, setQuery] = useState("");
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const [width, setWidth] = useState(loadWidth);
+  const [isDragging, setIsDragging] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const dragRef = useRef({ startX: 0, startWidth: 0 });
+
+  useEffect(() => {
+    if (open && mode === "browse")
+      setTimeout(() => inputRef.current?.focus(), 200);
+  }, [open, mode]);
+
+  const handleDragStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      dragRef.current = { startX: e.clientX, startWidth: width };
+      setIsDragging(true);
+    },
+    [width]
+  );
+
+  useEffect(() => {
+    if (!isDragging) return;
+
+    const handleMove = (e: MouseEvent) => {
+      const delta = e.clientX - dragRef.current.startX;
+      const next = Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, dragRef.current.startWidth + delta));
+      setWidth(next);
+    };
+    const handleUp = () => {
+      setIsDragging(false);
+      setWidth((w) => {
+        try { localStorage.setItem(STORAGE_KEY, String(w)); } catch {}
+        return w;
+      });
+    };
+
+    document.addEventListener("mousemove", handleMove);
+    document.addEventListener("mouseup", handleUp);
+    document.body.style.userSelect = "none";
+    document.body.style.cursor = "col-resize";
+    return () => {
+      document.removeEventListener("mousemove", handleMove);
+      document.removeEventListener("mouseup", handleUp);
+      document.body.style.userSelect = "";
+      document.body.style.cursor = "";
+    };
+  }, [isDragging]);
+
+  const realNodes = useMemo(() => nodes.filter((n) => !n.phantom), [nodes]);
+  const nodeMap = useMemo(
+    () => new Map(nodes.map((n) => [n.id, n])),
+    [nodes]
+  );
+
+  const categories = useMemo(() => {
+    const q = query.toLowerCase().trim();
+    const filtered = q
+      ? realNodes.filter(
+          (n) =>
+            n.title.toLowerCase().includes(q) ||
+            n.category.toLowerCase().includes(q)
+        )
+      : realNodes;
+
+    const map = new Map<
+      string,
+      { id: string; label: string; color: string; nodes: GraphNode[] }
+    >();
+    for (const node of filtered) {
+      if (!map.has(node.category)) {
+        map.set(node.category, {
+          id: node.category,
+          label: node.category
+            .replace(/-/g, " ")
+            .replace(/\b\w/g, (c) => c.toUpperCase()),
+          color: node.color,
+          nodes: [],
+        });
+      }
+      map.get(node.category)!.nodes.push(node);
+    }
+    for (const group of map.values()) {
+      group.nodes.sort(
+        (a, b) => b.val - a.val || a.title.localeCompare(b.title)
+      );
+    }
+    return Array.from(map.values()).sort(
+      (a, b) => b.nodes.length - a.nodes.length
+    );
+  }, [realNodes, query]);
+
+  const toggleSection = useCallback((id: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const handleSelect = useCallback(
+    (nodeId: string) => onNodeSelect(nodeId),
+    [onNodeSelect]
+  );
+
+  return (
+    <>
+      {open && (
+        <div
+          className="absolute inset-0 z-[39]"
+          onClick={onClose}
+          aria-hidden="true"
+        />
+      )}
+
+      <div
+        className="absolute left-0 top-0 bottom-0 z-40 flex"
+        style={{
+          width: `${width}px`,
+          transform: open ? "translateX(0)" : "translateX(-100%)",
+          transition: isDragging ? "none" : "transform 220ms cubic-bezier(0.4, 0, 0.2, 1)",
+          pointerEvents: open ? "auto" : "none",
+        }}
+      >
+      <div
+        className="flex-1 min-w-0 h-full flex flex-col"
+        style={{
+          backgroundColor: "var(--surface)",
+          borderRight: "1px solid var(--border)",
+          boxShadow: open
+            ? "4px 0 24px rgba(0,0,0,0.05), 1px 0 2px rgba(0,0,0,0.04)"
+            : "none",
+        }}
+      >
+        <div className="px-4 pt-11 md:pt-8 pb-2 flex items-center justify-between shrink-0">
+          <span className="text-[13px] font-medium tracking-wide text-text-secondary">
+            Explorer
+          </span>
+          <button
+            onClick={onClose}
+            className="w-6 h-6 flex items-center justify-center rounded-full text-text-muted hover:text-text-secondary hover:bg-[color-mix(in_srgb,var(--text-primary)_6%,transparent)] transition-colors"
+            aria-label="Close explorer"
+          >
+            <svg
+              width="11"
+              height="11"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="px-3 pb-2 shrink-0">
+          <div
+            className="flex items-center gap-0.5 p-0.5 rounded-lg"
+            style={{
+              backgroundColor:
+                "color-mix(in srgb, var(--text-primary) 4%, transparent)",
+            }}
+          >
+            <button
+              onClick={() => setMode("paths")}
+              className={`flex-1 py-1 rounded-md text-[11px] font-medium tracking-wide transition-all duration-150 ${
+                mode === "paths"
+                  ? "text-text-primary shadow-sm"
+                  : "text-text-muted hover:text-text-secondary"
+              }`}
+              style={
+                mode === "paths"
+                  ? {
+                      backgroundColor: "var(--surface)",
+                      boxShadow:
+                        "0 1px 3px rgba(0,0,0,0.06), 0 0 0 1px color-mix(in srgb, var(--text-primary) 6%, transparent)",
+                    }
+                  : undefined
+              }
+            >
+              Paths
+            </button>
+            <button
+              onClick={() => setMode("browse")}
+              className={`flex-1 py-1 rounded-md text-[11px] font-medium tracking-wide transition-all duration-150 ${
+                mode === "browse"
+                  ? "text-text-primary shadow-sm"
+                  : "text-text-muted hover:text-text-secondary"
+              }`}
+              style={
+                mode === "browse"
+                  ? {
+                      backgroundColor: "var(--surface)",
+                      boxShadow:
+                        "0 1px 3px rgba(0,0,0,0.06), 0 0 0 1px color-mix(in srgb, var(--text-primary) 6%, transparent)",
+                    }
+                  : undefined
+              }
+            >
+              Browse
+            </button>
+          </div>
+        </div>
+
+        {mode === "browse" && (
+          <div className="px-3 pb-2 shrink-0">
+            <div
+              className="flex items-center gap-2 px-3 h-8 rounded-lg transition-shadow"
+              style={{
+                backgroundColor:
+                  "color-mix(in srgb, var(--text-primary) 4%, transparent)",
+                boxShadow:
+                  "inset 0 0 0 1px color-mix(in srgb, var(--text-primary) 8%, transparent)",
+              }}
+            >
+              <svg
+                width="11"
+                height="11"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="text-text-muted shrink-0"
+              >
+                <circle cx="11" cy="11" r="8" />
+                <line x1="21" y1="21" x2="16.65" y2="16.65" />
+              </svg>
+              <input
+                ref={inputRef}
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Filter nodes…"
+                className="flex-1 bg-transparent text-[12px] text-text-primary placeholder:text-text-muted outline-none focus:outline-none focus:ring-0"
+              />
+              {query && (
+                <button
+                  onClick={() => setQuery("")}
+                  className="text-text-muted hover:text-text-secondary transition-colors"
+                  aria-label="Clear filter"
+                >
+                  <svg
+                    width="9"
+                    height="9"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="3"
+                    strokeLinecap="round"
+                  >
+                    <line x1="18" y1="6" x2="6" y2="18" />
+                    <line x1="6" y1="6" x2="18" y2="18" />
+                  </svg>
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+
+        <div className="flex-1 overflow-y-auto panel-scroll px-1.5 pb-3">
+          {mode === "paths" ? (
+            <div>
+              {READING_PATHS.map((path) => {
+                const isCollapsed = collapsed.has(path.id);
+                const pathNodes = path.nodes
+                  .map((pn) => ({ ...pn, node: nodeMap.get(pn.id) }))
+                  .filter((pn) => pn.node);
+
+                return (
+                  <div key={path.id} className="mb-1">
+                    <button
+                      onClick={() => toggleSection(path.id)}
+                      className="w-full flex items-start gap-2.5 px-2.5 py-2 rounded-lg text-left hover:bg-[color-mix(in_srgb,var(--text-primary)_4%,transparent)] transition-colors group"
+                    >
+                      <svg
+                        width="8"
+                        height="8"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="3"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className="text-text-muted/60 shrink-0 mt-[3px] transition-transform duration-150"
+                        style={{
+                          transform: isCollapsed
+                            ? "rotate(-90deg)"
+                            : "rotate(0deg)",
+                        }}
+                      >
+                        <polyline points="6 9 12 15 18 9" />
+                      </svg>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="text-[12px] font-medium text-text-primary">
+                            {path.title}
+                          </span>
+                          <span className="text-[9px] text-text-muted/40 tabular-nums ml-auto shrink-0">
+                            {pathNodes.length}
+                          </span>
+                        </div>
+                        <p className="text-[10px] text-text-muted/70 mt-0.5 leading-snug">
+                          {path.description}
+                        </p>
+                      </div>
+                    </button>
+
+                    <div
+                      className="overflow-hidden transition-all duration-200"
+                      style={{
+                        maxHeight: isCollapsed
+                          ? "0px"
+                          : `${pathNodes.length * 52 + 8}px`,
+                        opacity: isCollapsed ? 0 : 1,
+                      }}
+                    >
+                      <div className="ml-[22px] relative py-1">
+                        <div
+                          className="absolute left-[7px] top-4 bottom-4 w-px"
+                          style={{
+                            backgroundColor:
+                              "color-mix(in srgb, var(--text-primary) 8%, transparent)",
+                          }}
+                        />
+
+                        {pathNodes.map((pn, i) => (
+                          <button
+                            key={pn.id}
+                            onClick={() => handleSelect(pn.id)}
+                            className="w-full flex items-start gap-3 pl-1 pr-2.5 py-[5px] rounded-lg text-left hover:bg-[color-mix(in_srgb,var(--text-primary)_5%,transparent)] transition-colors group relative"
+                          >
+                            <span
+                              className="w-[9px] h-[9px] rounded-full shrink-0 mt-[3px] relative z-[1] border-2 group-hover:scale-110 transition-transform"
+                              style={{
+                                backgroundColor: "var(--surface)",
+                                borderColor:
+                                  pn.node?.color ?? "var(--text-muted)",
+                              }}
+                            />
+                            <div className="flex-1 min-w-0">
+                              <div className="flex items-center gap-1.5">
+                                <span className="text-[9px] text-text-muted/40 tabular-nums shrink-0 w-3 text-right">
+                                  {i + 1}
+                                </span>
+                                <span className="text-[12px] text-text-secondary group-hover:text-text-primary transition-colors truncate">
+                                  {pn.node?.title ?? pn.id}
+                                </span>
+                              </div>
+                              <p className="text-[10px] text-text-muted/50 group-hover:text-text-muted/80 transition-colors truncate mt-px ml-[18px]">
+                                {pn.hook}
+                              </p>
+                            </div>
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div>
+              {categories.map((cat) => {
+                const isCollapsed = collapsed.has(cat.id);
+                return (
+                  <div key={cat.id} className="mb-0.5">
+                    <button
+                      onClick={() => toggleSection(cat.id)}
+                      className="w-full flex items-center gap-2 px-2.5 py-[7px] rounded-lg text-left hover:bg-[color-mix(in_srgb,var(--text-primary)_4%,transparent)] transition-colors group"
+                    >
+                      <svg
+                        width="8"
+                        height="8"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="3"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className="text-text-muted/60 shrink-0 transition-transform duration-150"
+                        style={{
+                          transform: isCollapsed
+                            ? "rotate(-90deg)"
+                            : "rotate(0deg)",
+                        }}
+                      >
+                        <polyline points="6 9 12 15 18 9" />
+                      </svg>
+                      <span
+                        className="w-[7px] h-[7px] rounded-full shrink-0"
+                        style={{ backgroundColor: cat.color }}
+                      />
+                      <span className="text-[11px] font-medium text-text-secondary tracking-wide flex-1">
+                        {cat.label}
+                      </span>
+                      <span className="text-[10px] text-text-muted/50 tabular-nums">
+                        {cat.nodes.length}
+                      </span>
+                    </button>
+
+                    <div
+                      className="overflow-hidden transition-all duration-150"
+                      style={{
+                        maxHeight: isCollapsed
+                          ? "0px"
+                          : `${cat.nodes.length * 36}px`,
+                        opacity: isCollapsed ? 0 : 1,
+                      }}
+                    >
+                      <div className="ml-[18px]">
+                        {cat.nodes.map((node) => (
+                          <button
+                            key={node.id}
+                            onClick={() => handleSelect(node.id)}
+                            className="w-full flex items-center gap-2.5 px-2.5 py-[6px] rounded-lg text-left hover:bg-[color-mix(in_srgb,var(--text-primary)_5%,transparent)] transition-colors group"
+                          >
+                            <span
+                              className="w-[5px] h-[5px] rounded-full shrink-0 opacity-40 group-hover:opacity-80 transition-opacity"
+                              style={{ backgroundColor: node.color }}
+                            />
+                            <span className="text-[12px] text-text-secondary group-hover:text-text-primary transition-colors truncate flex-1">
+                              {node.title}
+                            </span>
+                            <span className="text-[9px] text-text-muted/40 tabular-nums shrink-0 group-hover:text-text-muted/70 transition-colors">
+                              {node.val}
+                            </span>
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+
+              {categories.length === 0 && query && (
+                <div className="px-3 py-8 text-center text-[12px] text-text-muted">
+                  No matching nodes
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div
+          className="px-4 py-2.5 shrink-0 flex items-center justify-between"
+          style={{ borderTop: "1px solid var(--border)" }}
+        >
+          <span className="text-[10px] text-text-muted/60">
+            {mode === "paths"
+              ? `${READING_PATHS.length} paths`
+              : `${realNodes.length} nodes`}
+          </span>
+          <kbd className="text-[9px] text-text-muted/40 tracking-wide">⌘B</kbd>
+        </div>
+      </div>
+
+      <div
+        onMouseDown={handleDragStart}
+        className="w-[6px] shrink-0 cursor-col-resize group relative"
+        role="separator"
+        aria-orientation="vertical"
+        aria-valuemin={MIN_WIDTH}
+        aria-valuemax={MAX_WIDTH}
+        aria-valuenow={width}
+      >
+        <div
+          className={`absolute inset-y-0 left-[2px] w-[2px] rounded-full transition-opacity duration-150 ${
+            isDragging
+              ? "opacity-100"
+              : "opacity-0 group-hover:opacity-100"
+          }`}
+          style={{
+            backgroundColor:
+              "color-mix(in srgb, var(--text-primary) 15%, transparent)",
+          }}
+        />
+      </div>
+    </div>
+    </>
+  );
+}

--- a/components/ExplorerPanel.tsx
+++ b/components/ExplorerPanel.tsx
@@ -49,6 +49,7 @@ export default function ExplorerPanel({
       setTimeout(() => inputRef.current?.focus(), 200);
   }, [open, mode]);
 
+  // --- Drag resize ---
   const handleDragStart = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
@@ -60,7 +61,6 @@ export default function ExplorerPanel({
 
   useEffect(() => {
     if (!isDragging) return;
-
     const handleMove = (e: MouseEvent) => {
       const delta = e.clientX - dragRef.current.startX;
       const next = Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, dragRef.current.startWidth + delta));
@@ -73,7 +73,6 @@ export default function ExplorerPanel({
         return w;
       });
     };
-
     document.addEventListener("mousemove", handleMove);
     document.addEventListener("mouseup", handleUp);
     document.body.style.userSelect = "none";
@@ -147,14 +146,15 @@ export default function ExplorerPanel({
     <>
       {open && (
         <div
-          className="absolute inset-0 z-[39]"
+          className="absolute inset-0 z-[39] transition-opacity duration-200"
+          style={{ backgroundColor: "rgba(0, 0, 0, 0.15)" }}
           onClick={onClose}
           aria-hidden="true"
         />
       )}
 
       <div
-        className="absolute left-0 top-0 bottom-0 z-40 flex"
+        className="absolute left-0 top-0 bottom-0 z-40 flex p-2.5"
         style={{
           width: `${width}px`,
           transform: open ? "translateX(0)" : "translateX(-100%)",
@@ -162,99 +162,76 @@ export default function ExplorerPanel({
           pointerEvents: open ? "auto" : "none",
         }}
       >
-      <div
-        className="flex-1 min-w-0 h-full flex flex-col"
-        style={{
-          backgroundColor: "var(--surface)",
-          borderRight: "1px solid var(--border)",
-          boxShadow: open
-            ? "4px 0 24px rgba(0,0,0,0.05), 1px 0 2px rgba(0,0,0,0.04)"
-            : "none",
-        }}
-      >
-        <div className="px-4 pt-11 md:pt-8 pb-2 flex items-center justify-between shrink-0">
-          <span className="text-[13px] font-medium tracking-wide text-text-secondary">
-            Explorer
-          </span>
-          <button
-            onClick={onClose}
-            className="w-6 h-6 flex items-center justify-center rounded-full text-text-muted hover:text-text-secondary hover:bg-[color-mix(in_srgb,var(--text-primary)_6%,transparent)] transition-colors"
-            aria-label="Close explorer"
-          >
-            <svg
-              width="11"
-              height="11"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2.5"
-              strokeLinecap="round"
-            >
-              <line x1="18" y1="6" x2="6" y2="18" />
-              <line x1="6" y1="6" x2="18" y2="18" />
-            </svg>
-          </button>
-        </div>
-
-        <div className="px-3 pb-2 shrink-0">
-          <div
-            className="flex items-center gap-0.5 p-0.5 rounded-lg"
-            style={{
-              backgroundColor:
-                "color-mix(in srgb, var(--text-primary) 4%, transparent)",
-            }}
-          >
-            <button
-              onClick={() => setMode("paths")}
-              className={`flex-1 py-1 rounded-md text-[11px] font-medium tracking-wide transition-all duration-150 ${
-                mode === "paths"
-                  ? "text-text-primary shadow-sm"
-                  : "text-text-muted hover:text-text-secondary"
-              }`}
-              style={
-                mode === "paths"
-                  ? {
-                      backgroundColor: "var(--surface)",
-                      boxShadow:
-                        "0 1px 3px rgba(0,0,0,0.06), 0 0 0 1px color-mix(in srgb, var(--text-primary) 6%, transparent)",
-                    }
-                  : undefined
-              }
-            >
-              Paths
-            </button>
-            <button
-              onClick={() => setMode("browse")}
-              className={`flex-1 py-1 rounded-md text-[11px] font-medium tracking-wide transition-all duration-150 ${
-                mode === "browse"
-                  ? "text-text-primary shadow-sm"
-                  : "text-text-muted hover:text-text-secondary"
-              }`}
-              style={
-                mode === "browse"
-                  ? {
-                      backgroundColor: "var(--surface)",
-                      boxShadow:
-                        "0 1px 3px rgba(0,0,0,0.06), 0 0 0 1px color-mix(in srgb, var(--text-primary) 6%, transparent)",
-                    }
-                  : undefined
-              }
-            >
-              Browse
-            </button>
-          </div>
-        </div>
-
-        {mode === "browse" && (
-          <div className="px-3 pb-2 shrink-0">
+        <div
+          className="flex-1 min-w-0 h-full flex flex-col rounded-2xl overflow-hidden"
+          style={{
+            backgroundColor: "color-mix(in srgb, var(--surface) 82%, transparent)",
+            backdropFilter: "blur(24px) saturate(1.4)",
+            WebkitBackdropFilter: "blur(24px) saturate(1.4)",
+            border: "1px solid color-mix(in srgb, var(--text-primary) 8%, transparent)",
+            boxShadow: open
+              ? "4px 0 32px rgba(0,0,0,0.08), 0 0 0 1px rgba(0,0,0,0.02)"
+              : "none",
+          }}
+        >
+          <div className="flex items-center justify-between px-3 md:px-5 pt-10 md:pt-7 pb-4 shrink-0">
             <div
-              className="flex items-center gap-2 px-3 h-8 rounded-lg transition-shadow"
+              className="flex items-center gap-0.5 p-0.5 rounded-full"
               style={{
                 backgroundColor:
-                  "color-mix(in srgb, var(--text-primary) 4%, transparent)",
+                  "color-mix(in srgb, var(--text-primary) 5%, transparent)",
                 boxShadow:
                   "inset 0 0 0 1px color-mix(in srgb, var(--text-primary) 8%, transparent)",
               }}
+            >
+              <button
+                onClick={() => setMode("paths")}
+                className={`px-4 py-1.5 rounded-full text-[12px] font-medium tracking-wide transition-all duration-150 leading-none ${
+                  mode === "paths"
+                    ? "text-text-primary"
+                    : "text-text-muted hover:text-text-secondary"
+                }`}
+                style={
+                  mode === "paths"
+                    ? {
+                        backgroundColor: "color-mix(in srgb, var(--surface) 90%, transparent)",
+                        boxShadow:
+                          "0 1px 3px rgba(0,0,0,0.06), 0 0 0 1px color-mix(in srgb, var(--text-primary) 8%, transparent)",
+                      }
+                    : undefined
+                }
+              >
+                Paths
+              </button>
+              <button
+                onClick={() => setMode("browse")}
+                className={`px-4 py-1.5 rounded-full text-[12px] font-medium tracking-wide transition-all duration-150 leading-none ${
+                  mode === "browse"
+                    ? "text-text-primary"
+                    : "text-text-muted hover:text-text-secondary"
+                }`}
+                style={
+                  mode === "browse"
+                    ? {
+                        backgroundColor: "color-mix(in srgb, var(--surface) 90%, transparent)",
+                        boxShadow:
+                          "0 1px 3px rgba(0,0,0,0.06), 0 0 0 1px color-mix(in srgb, var(--text-primary) 8%, transparent)",
+                      }
+                    : undefined
+                }
+              >
+                Browse
+              </button>
+            </div>
+
+            <button
+              onClick={onClose}
+              className="flex items-center justify-center gap-2 px-3 py-1.5 rounded-full text-text-muted hover:text-text-secondary transition-all text-[11px] tracking-wide leading-none"
+              style={{
+                backgroundColor: "color-mix(in srgb, var(--text-primary) 5%, transparent)",
+                boxShadow: "inset 0 0 0 1px color-mix(in srgb, var(--text-primary) 8%, transparent)",
+              }}
+              aria-label="Close explorer"
             >
               <svg
                 width="11"
@@ -264,263 +241,291 @@ export default function ExplorerPanel({
                 stroke="currentColor"
                 strokeWidth="2.5"
                 strokeLinecap="round"
-                strokeLinejoin="round"
-                className="text-text-muted shrink-0"
               >
-                <circle cx="11" cy="11" r="8" />
-                <line x1="21" y1="21" x2="16.65" y2="16.65" />
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
               </svg>
-              <input
-                ref={inputRef}
-                type="text"
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                placeholder="Filter nodes…"
-                className="flex-1 bg-transparent text-[12px] text-text-primary placeholder:text-text-muted outline-none focus:outline-none focus:ring-0"
-              />
-              {query && (
-                <button
-                  onClick={() => setQuery("")}
-                  className="text-text-muted hover:text-text-secondary transition-colors"
-                  aria-label="Clear filter"
-                >
-                  <svg
-                    width="9"
-                    height="9"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="3"
-                    strokeLinecap="round"
-                  >
-                    <line x1="18" y1="6" x2="6" y2="18" />
-                    <line x1="6" y1="6" x2="18" y2="18" />
-                  </svg>
-                </button>
-              )}
-            </div>
+              <span className="hidden sm:inline">Close</span>
+              <kbd className="hidden md:inline text-[10px] text-text-muted/50 ml-0.5">⌘B</kbd>
+            </button>
           </div>
-        )}
 
-        <div className="flex-1 overflow-y-auto panel-scroll px-1.5 pb-3">
-          {mode === "paths" ? (
-            <div>
-              {READING_PATHS.map((path) => {
-                const isCollapsed = collapsed.has(path.id);
-                const pathNodes = path.nodes
-                  .map((pn) => ({ ...pn, node: nodeMap.get(pn.id) }))
-                  .filter((pn) => pn.node);
-
-                return (
-                  <div key={path.id} className="mb-1">
-                    <button
-                      onClick={() => toggleSection(path.id)}
-                      className="w-full flex items-start gap-2.5 px-2.5 py-2 rounded-lg text-left hover:bg-[color-mix(in_srgb,var(--text-primary)_4%,transparent)] transition-colors group"
+          {mode === "browse" && (
+            <div className="px-3 md:px-5 pb-2.5 shrink-0">
+              <div
+                className="flex items-center gap-2 px-3 h-8 rounded-lg transition-shadow"
+                style={{
+                  backgroundColor:
+                    "color-mix(in srgb, var(--text-primary) 4%, transparent)",
+                  boxShadow:
+                    "inset 0 0 0 1px color-mix(in srgb, var(--text-primary) 8%, transparent)",
+                }}
+              >
+                <svg
+                  width="11"
+                  height="11"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="text-text-muted shrink-0"
+                >
+                  <circle cx="11" cy="11" r="8" />
+                  <line x1="21" y1="21" x2="16.65" y2="16.65" />
+                </svg>
+                <input
+                  ref={inputRef}
+                  type="text"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="Filter nodes…"
+                  className="flex-1 bg-transparent text-[12px] text-text-primary placeholder:text-text-muted outline-none focus:outline-none focus:ring-0"
+                />
+                {query && (
+                  <button
+                    onClick={() => setQuery("")}
+                    className="text-text-muted hover:text-text-secondary transition-colors"
+                    aria-label="Clear filter"
+                  >
+                    <svg
+                      width="9"
+                      height="9"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="3"
+                      strokeLinecap="round"
                     >
-                      <svg
-                        width="8"
-                        height="8"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="3"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        className="text-text-muted/60 shrink-0 mt-[3px] transition-transform duration-150"
-                        style={{
-                          transform: isCollapsed
-                            ? "rotate(-90deg)"
-                            : "rotate(0deg)",
-                        }}
-                      >
-                        <polyline points="6 9 12 15 18 9" />
-                      </svg>
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2">
-                          <span className="text-[12px] font-medium text-text-primary">
-                            {path.title}
-                          </span>
-                          <span className="text-[9px] text-text-muted/40 tabular-nums ml-auto shrink-0">
-                            {pathNodes.length}
-                          </span>
-                        </div>
-                        <p className="text-[10px] text-text-muted/70 mt-0.5 leading-snug">
-                          {path.description}
-                        </p>
-                      </div>
-                    </button>
-
-                    <div
-                      className="overflow-hidden transition-all duration-200"
-                      style={{
-                        maxHeight: isCollapsed
-                          ? "0px"
-                          : `${pathNodes.length * 52 + 8}px`,
-                        opacity: isCollapsed ? 0 : 1,
-                      }}
-                    >
-                      <div className="ml-[22px] relative py-1">
-                        <div
-                          className="absolute left-[7px] top-4 bottom-4 w-px"
-                          style={{
-                            backgroundColor:
-                              "color-mix(in srgb, var(--text-primary) 8%, transparent)",
-                          }}
-                        />
-
-                        {pathNodes.map((pn, i) => (
-                          <button
-                            key={pn.id}
-                            onClick={() => handleSelect(pn.id)}
-                            className="w-full flex items-start gap-3 pl-1 pr-2.5 py-[5px] rounded-lg text-left hover:bg-[color-mix(in_srgb,var(--text-primary)_5%,transparent)] transition-colors group relative"
-                          >
-                            <span
-                              className="w-[9px] h-[9px] rounded-full shrink-0 mt-[3px] relative z-[1] border-2 group-hover:scale-110 transition-transform"
-                              style={{
-                                backgroundColor: "var(--surface)",
-                                borderColor:
-                                  pn.node?.color ?? "var(--text-muted)",
-                              }}
-                            />
-                            <div className="flex-1 min-w-0">
-                              <div className="flex items-center gap-1.5">
-                                <span className="text-[9px] text-text-muted/40 tabular-nums shrink-0 w-3 text-right">
-                                  {i + 1}
-                                </span>
-                                <span className="text-[12px] text-text-secondary group-hover:text-text-primary transition-colors truncate">
-                                  {pn.node?.title ?? pn.id}
-                                </span>
-                              </div>
-                              <p className="text-[10px] text-text-muted/50 group-hover:text-text-muted/80 transition-colors truncate mt-px ml-[18px]">
-                                {pn.hook}
-                              </p>
-                            </div>
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          ) : (
-            <div>
-              {categories.map((cat) => {
-                const isCollapsed = collapsed.has(cat.id);
-                return (
-                  <div key={cat.id} className="mb-0.5">
-                    <button
-                      onClick={() => toggleSection(cat.id)}
-                      className="w-full flex items-center gap-2 px-2.5 py-[7px] rounded-lg text-left hover:bg-[color-mix(in_srgb,var(--text-primary)_4%,transparent)] transition-colors group"
-                    >
-                      <svg
-                        width="8"
-                        height="8"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="3"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        className="text-text-muted/60 shrink-0 transition-transform duration-150"
-                        style={{
-                          transform: isCollapsed
-                            ? "rotate(-90deg)"
-                            : "rotate(0deg)",
-                        }}
-                      >
-                        <polyline points="6 9 12 15 18 9" />
-                      </svg>
-                      <span
-                        className="w-[7px] h-[7px] rounded-full shrink-0"
-                        style={{ backgroundColor: cat.color }}
-                      />
-                      <span className="text-[11px] font-medium text-text-secondary tracking-wide flex-1">
-                        {cat.label}
-                      </span>
-                      <span className="text-[10px] text-text-muted/50 tabular-nums">
-                        {cat.nodes.length}
-                      </span>
-                    </button>
-
-                    <div
-                      className="overflow-hidden transition-all duration-150"
-                      style={{
-                        maxHeight: isCollapsed
-                          ? "0px"
-                          : `${cat.nodes.length * 36}px`,
-                        opacity: isCollapsed ? 0 : 1,
-                      }}
-                    >
-                      <div className="ml-[18px]">
-                        {cat.nodes.map((node) => (
-                          <button
-                            key={node.id}
-                            onClick={() => handleSelect(node.id)}
-                            className="w-full flex items-center gap-2.5 px-2.5 py-[6px] rounded-lg text-left hover:bg-[color-mix(in_srgb,var(--text-primary)_5%,transparent)] transition-colors group"
-                          >
-                            <span
-                              className="w-[5px] h-[5px] rounded-full shrink-0 opacity-40 group-hover:opacity-80 transition-opacity"
-                              style={{ backgroundColor: node.color }}
-                            />
-                            <span className="text-[12px] text-text-secondary group-hover:text-text-primary transition-colors truncate flex-1">
-                              {node.title}
-                            </span>
-                            <span className="text-[9px] text-text-muted/40 tabular-nums shrink-0 group-hover:text-text-muted/70 transition-colors">
-                              {node.val}
-                            </span>
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-                );
-              })}
-
-              {categories.length === 0 && query && (
-                <div className="px-3 py-8 text-center text-[12px] text-text-muted">
-                  No matching nodes
-                </div>
-              )}
+                      <line x1="18" y1="6" x2="6" y2="18" />
+                      <line x1="6" y1="6" x2="18" y2="18" />
+                    </svg>
+                  </button>
+                )}
+              </div>
             </div>
           )}
+
+          <div className="flex-1 overflow-y-auto panel-scroll px-1.5 pb-3">
+            {mode === "paths" ? (
+              <div>
+                {READING_PATHS.map((path) => {
+                  const isCollapsed = collapsed.has(path.id);
+                  const pathNodes = path.nodes
+                    .map((pn) => ({ ...pn, node: nodeMap.get(pn.id) }))
+                    .filter((pn) => pn.node);
+
+                  return (
+                    <div key={path.id} className="mb-1">
+                      <button
+                        onClick={() => toggleSection(path.id)}
+                        className="w-full flex items-start gap-2.5 px-2.5 py-2 rounded-lg text-left hover:bg-[color-mix(in_srgb,var(--text-primary)_4%,transparent)] transition-colors group"
+                      >
+                        <svg
+                          width="8"
+                          height="8"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="3"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          className="text-text-muted/60 shrink-0 mt-[3px] transition-transform duration-150"
+                          style={{
+                            transform: isCollapsed
+                              ? "rotate(-90deg)"
+                              : "rotate(0deg)",
+                          }}
+                        >
+                          <polyline points="6 9 12 15 18 9" />
+                        </svg>
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2">
+                            <span className="text-[12px] font-medium text-text-primary">
+                              {path.title}
+                            </span>
+                            <span className="text-[9px] text-text-muted/40 tabular-nums ml-auto shrink-0">
+                              {pathNodes.length}
+                            </span>
+                          </div>
+                          <p className="text-[10px] text-text-muted/70 mt-0.5 leading-snug">
+                            {path.description}
+                          </p>
+                        </div>
+                      </button>
+
+                      <div
+                        className="overflow-hidden transition-all duration-200"
+                        style={{
+                          maxHeight: isCollapsed
+                            ? "0px"
+                            : `${pathNodes.length * 52 + 8}px`,
+                          opacity: isCollapsed ? 0 : 1,
+                        }}
+                      >
+                        <div className="ml-[22px] relative py-1">
+                          <div
+                            className="absolute left-[7px] top-4 bottom-4 w-px"
+                            style={{
+                              backgroundColor:
+                                "color-mix(in srgb, var(--text-primary) 8%, transparent)",
+                            }}
+                          />
+
+                          {pathNodes.map((pn, i) => (
+                            <button
+                              key={pn.id}
+                              onClick={() => handleSelect(pn.id)}
+                              className="w-full flex items-start gap-3 pl-1 pr-2.5 py-[5px] rounded-lg text-left hover:bg-[color-mix(in_srgb,var(--text-primary)_5%,transparent)] transition-colors group relative"
+                            >
+                              <span
+                                className="w-[9px] h-[9px] rounded-full shrink-0 mt-[3px] relative z-[1] border-2 group-hover:scale-110 transition-transform"
+                                style={{
+                                  backgroundColor: "color-mix(in srgb, var(--surface) 80%, transparent)",
+                                  borderColor:
+                                    pn.node?.color ?? "var(--text-muted)",
+                                }}
+                              />
+                              <div className="flex-1 min-w-0">
+                                <div className="flex items-center gap-1.5">
+                                  <span className="text-[9px] text-text-muted/40 tabular-nums shrink-0 w-3 text-right">
+                                    {i + 1}
+                                  </span>
+                                  <span className="text-[12px] text-text-secondary group-hover:text-text-primary transition-colors truncate">
+                                    {pn.node?.title ?? pn.id}
+                                  </span>
+                                </div>
+                                <p className="text-[10px] text-text-muted/50 group-hover:text-text-muted/80 transition-colors truncate mt-px ml-[18px]">
+                                  {pn.hook}
+                                </p>
+                              </div>
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <div>
+                {categories.map((cat) => {
+                  const isCollapsed = collapsed.has(cat.id);
+                  return (
+                    <div key={cat.id} className="mb-0.5">
+                      <button
+                        onClick={() => toggleSection(cat.id)}
+                        className="w-full flex items-center gap-2 px-2.5 py-[7px] rounded-lg text-left hover:bg-[color-mix(in_srgb,var(--text-primary)_4%,transparent)] transition-colors group"
+                      >
+                        <svg
+                          width="8"
+                          height="8"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="3"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          className="text-text-muted/60 shrink-0 transition-transform duration-150"
+                          style={{
+                            transform: isCollapsed
+                              ? "rotate(-90deg)"
+                              : "rotate(0deg)",
+                          }}
+                        >
+                          <polyline points="6 9 12 15 18 9" />
+                        </svg>
+                        <span
+                          className="w-[7px] h-[7px] rounded-full shrink-0"
+                          style={{ backgroundColor: cat.color }}
+                        />
+                        <span className="text-[11px] font-medium text-text-secondary tracking-wide flex-1">
+                          {cat.label}
+                        </span>
+                        <span className="text-[10px] text-text-muted/50 tabular-nums">
+                          {cat.nodes.length}
+                        </span>
+                      </button>
+
+                      <div
+                        className="overflow-hidden transition-all duration-150"
+                        style={{
+                          maxHeight: isCollapsed
+                            ? "0px"
+                            : `${cat.nodes.length * 36}px`,
+                          opacity: isCollapsed ? 0 : 1,
+                        }}
+                      >
+                        <div className="ml-[18px]">
+                          {cat.nodes.map((node) => (
+                            <button
+                              key={node.id}
+                              onClick={() => handleSelect(node.id)}
+                              className="w-full flex items-center gap-2.5 px-2.5 py-[6px] rounded-lg text-left hover:bg-[color-mix(in_srgb,var(--text-primary)_5%,transparent)] transition-colors group"
+                            >
+                              <span
+                                className="w-[5px] h-[5px] rounded-full shrink-0 opacity-40 group-hover:opacity-80 transition-opacity"
+                                style={{ backgroundColor: node.color }}
+                              />
+                              <span className="text-[12px] text-text-secondary group-hover:text-text-primary transition-colors truncate flex-1">
+                                {node.title}
+                              </span>
+                              <span className="text-[9px] text-text-muted/40 tabular-nums shrink-0 group-hover:text-text-muted/70 transition-colors">
+                                {node.val}
+                              </span>
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+
+                {categories.length === 0 && query && (
+                  <div className="px-3 py-8 text-center text-[12px] text-text-muted">
+                    No matching nodes
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+
+          <div
+            className="px-4 py-2.5 shrink-0 flex items-center justify-between"
+            style={{ borderTop: "1px solid color-mix(in srgb, var(--text-primary) 6%, transparent)" }}
+          >
+            <span className="text-[10px] text-text-muted/60">
+              {mode === "paths"
+                ? `${READING_PATHS.length} paths`
+                : `${realNodes.length} nodes`}
+            </span>
+            <kbd className="text-[9px] text-text-muted/40 tracking-wide">⌘B</kbd>
+          </div>
         </div>
 
         <div
-          className="px-4 py-2.5 shrink-0 flex items-center justify-between"
-          style={{ borderTop: "1px solid var(--border)" }}
+          onMouseDown={handleDragStart}
+          className="absolute right-0 top-0 bottom-0 w-3 cursor-col-resize group flex items-center justify-center"
+          role="separator"
+          aria-orientation="vertical"
+          aria-valuemin={MIN_WIDTH}
+          aria-valuemax={MAX_WIDTH}
+          aria-valuenow={width}
         >
-          <span className="text-[10px] text-text-muted/60">
-            {mode === "paths"
-              ? `${READING_PATHS.length} paths`
-              : `${realNodes.length} nodes`}
-          </span>
-          <kbd className="text-[9px] text-text-muted/40 tracking-wide">⌘B</kbd>
+          <div
+            className={`w-[3px] h-10 rounded-full transition-opacity duration-150 ${
+              isDragging
+                ? "opacity-100"
+                : "opacity-0 group-hover:opacity-100"
+            }`}
+            style={{
+              backgroundColor:
+                "color-mix(in srgb, var(--text-primary) 20%, transparent)",
+            }}
+          />
         </div>
       </div>
-
-      <div
-        onMouseDown={handleDragStart}
-        className="w-[6px] shrink-0 cursor-col-resize group relative"
-        role="separator"
-        aria-orientation="vertical"
-        aria-valuemin={MIN_WIDTH}
-        aria-valuemax={MAX_WIDTH}
-        aria-valuenow={width}
-      >
-        <div
-          className={`absolute inset-y-0 left-[2px] w-[2px] rounded-full transition-opacity duration-150 ${
-            isDragging
-              ? "opacity-100"
-              : "opacity-0 group-hover:opacity-100"
-          }`}
-          style={{
-            backgroundColor:
-              "color-mix(in srgb, var(--text-primary) 15%, transparent)",
-          }}
-        />
-      </div>
-    </div>
     </>
   );
 }

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -6,9 +6,11 @@ import ThemeToggle from "./ThemeToggle";
 interface Props {
   onLogoClick?: () => void;
   onSearchClick?: () => void;
+  onExplorerToggle?: () => void;
+  explorerOpen?: boolean;
 }
 
-export default function Navbar({ onLogoClick, onSearchClick }: Props) {
+export default function Navbar({ onLogoClick, onSearchClick, onExplorerToggle, explorerOpen }: Props) {
   const logoContent = (
     <div className="flex flex-col text-left">
       <span className="text-[15px] font-semibold tracking-[0.14em] text-text-primary leading-tight capitalize">
@@ -38,6 +40,41 @@ export default function Navbar({ onLogoClick, onSearchClick }: Props) {
         </Link>
       )}
       <div className="flex items-center gap-4">
+        {onExplorerToggle && (
+          <button
+            onClick={onExplorerToggle}
+            className={`flex items-center justify-center gap-2 px-3 py-1.5 rounded-full transition-all text-[11px] tracking-wide leading-none ${
+              explorerOpen
+                ? "text-text-secondary"
+                : "text-text-muted hover:text-text-secondary"
+            }`}
+            style={{
+              backgroundColor: explorerOpen
+                ? "color-mix(in srgb, var(--text-primary) 9%, transparent)"
+                : "color-mix(in srgb, var(--text-primary) 5%, transparent)",
+              boxShadow: explorerOpen
+                ? "inset 0 0 0 1px color-mix(in srgb, var(--text-primary) 15%, transparent)"
+                : "inset 0 0 0 1px color-mix(in srgb, var(--text-primary) 10%, transparent)",
+            }}
+            aria-label="Toggle explorer"
+          >
+            <svg
+              width="13"
+              height="13"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <rect x="3" y="3" width="18" height="18" rx="2" />
+              <line x1="9" y1="3" x2="9" y2="21" />
+            </svg>
+            <span className="hidden sm:inline">Explorer</span>
+            <kbd className="hidden md:inline text-[10px] text-text-muted/70 ml-1">⌘B</kbd>
+          </button>
+        )}
         {onSearchClick && (
           <button
             onClick={onSearchClick}

--- a/components/NodeView.tsx
+++ b/components/NodeView.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useRef, useEffect, useMemo, useState } from "react";
 import dynamic from "next/dynamic";
 import type { GraphNode, GraphLink } from "@/lib/types";
+import { READING_PATHS } from "@/lib/paths";
 
 const MiniGraph = dynamic(() => import("./MiniGraph"), { ssr: false });
 
@@ -260,6 +261,12 @@ export default function NodeView({
             ref={contentRef}
             className="prose-apeiron"
             dangerouslySetInnerHTML={{ __html: mainHtml }}
+          />
+
+          <ReadNext
+            nodeId={node.id}
+            allNodes={allNodes}
+            onNodeClick={onNodeClick}
           />
 
           <div className="clear-both" />
@@ -543,6 +550,158 @@ function ConnectionReasons({
                 </span>
               </div>
             </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ReadNext({
+  nodeId,
+  allNodes,
+  onNodeClick,
+}: {
+  nodeId: string;
+  allNodes: GraphNode[];
+  onNodeClick: (id: string) => void;
+}) {
+  const nodeMap = useMemo(
+    () => new Map(allNodes.map((n) => [n.id, n])),
+    [allNodes]
+  );
+
+  const suggestions = useMemo(() => {
+    const results: {
+      pathTitle: string;
+      pathId: string;
+      node: GraphNode;
+      hook: string;
+      label: string;
+      isNextPath?: boolean;
+    }[] = [];
+    const seen = new Set<string>();
+
+    for (let pi = 0; pi < READING_PATHS.length; pi++) {
+      const path = READING_PATHS[pi];
+      const idx = path.nodes.findIndex((pn) => pn.id === nodeId);
+      if (idx === -1) continue;
+
+      if (idx < path.nodes.length - 1) {
+        const next = path.nodes[idx + 1];
+        if (seen.has(next.id)) continue;
+        const nextNode = nodeMap.get(next.id);
+        if (!nextNode) continue;
+        seen.add(next.id);
+        results.push({
+          pathTitle: path.title,
+          pathId: path.id,
+          node: nextNode,
+          hook: next.hook,
+          label: `${idx + 2} of ${path.nodes.length}`,
+        });
+      } else {
+        const nextPath = READING_PATHS[pi + 1];
+        if (!nextPath || nextPath.nodes.length === 0) continue;
+        const first = nextPath.nodes[0];
+        if (seen.has(`path:${nextPath.id}`)) continue;
+        const firstNode = nodeMap.get(first.id);
+        if (!firstNode) continue;
+        seen.add(`path:${nextPath.id}`);
+        results.push({
+          pathTitle: nextPath.title,
+          pathId: nextPath.id,
+          node: firstNode,
+          hook: nextPath.description,
+          label: `1 of ${nextPath.nodes.length}`,
+          isNextPath: true,
+        });
+      }
+    }
+    return results;
+  }, [nodeId, nodeMap]);
+
+  if (suggestions.length === 0) return null;
+
+  return (
+    <div className="mt-14 mb-8">
+      <div
+        className="w-full h-px mb-8"
+        style={{ backgroundColor: "color-mix(in srgb, var(--text-primary) 6%, transparent)" }}
+      />
+      <h3 className="text-[11px] font-semibold text-text-muted uppercase tracking-wider mb-4">
+        Read next
+      </h3>
+      <div
+        className="grid gap-3"
+        style={{
+          gridTemplateColumns:
+            suggestions.length > 1
+              ? "repeat(auto-fit, minmax(260px, 1fr))"
+              : "1fr",
+        }}
+      >
+        {suggestions.map((s) => (
+          <button
+            key={`${s.pathId}-${s.node.id}`}
+            onClick={() => onNodeClick(s.node.id)}
+            className="group text-left rounded-xl p-4 transition-all duration-150 hover:scale-[1.01]"
+            style={{
+              backgroundColor:
+                "color-mix(in srgb, var(--text-primary) 3%, transparent)",
+              boxShadow:
+                "inset 0 0 0 1px color-mix(in srgb, var(--text-primary) 7%, transparent)",
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.backgroundColor =
+                "color-mix(in srgb, var(--text-primary) 6%, transparent)";
+              e.currentTarget.style.boxShadow = `inset 0 0 0 1px ${s.node.color}33`;
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.backgroundColor =
+                "color-mix(in srgb, var(--text-primary) 3%, transparent)";
+              e.currentTarget.style.boxShadow =
+                "inset 0 0 0 1px color-mix(in srgb, var(--text-primary) 7%, transparent)";
+            }}
+          >
+            <div className="flex items-center gap-2 mb-2">
+              <span className="text-[10px] text-text-muted/50 tracking-wide">
+                {s.isNextPath ? "Next path" : s.pathTitle}
+              </span>
+              {s.isNextPath && (
+                <span className="text-[10px] text-text-muted/35 tracking-wide">
+                  — {s.pathTitle}
+                </span>
+              )}
+              <span className="text-[9px] text-text-muted/30 tabular-nums ml-auto">
+                {s.label}
+              </span>
+            </div>
+            <div className="flex items-center gap-3">
+              <span
+                className="w-2 h-2 rounded-full shrink-0"
+                style={{ backgroundColor: s.node.color }}
+              />
+              <span className="text-[15px] font-medium text-text-primary group-hover:text-text-primary/90 transition-colors">
+                {s.node.title}
+              </span>
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="ml-auto shrink-0 text-text-muted/30 group-hover:text-text-muted/70 group-hover:translate-x-0.5 transition-all"
+              >
+                <polyline points="9 18 15 12 9 6" />
+              </svg>
+            </div>
+            <p className="text-[12px] text-text-muted/60 group-hover:text-text-muted/80 transition-colors mt-1.5 ml-5 leading-snug">
+              {s.hook}
+            </p>
           </button>
         ))}
       </div>

--- a/components/PageClient.tsx
+++ b/components/PageClient.tsx
@@ -7,6 +7,7 @@ import Navbar from "./Navbar";
 import TabBar, { type Tab } from "./TabBar";
 import NodeView from "./NodeView";
 import CommandPalette from "./CommandPalette";
+import ExplorerPanel from "./ExplorerPanel";
 
 const Graph = dynamic(() => import("./Graph"), { ssr: false });
 
@@ -28,6 +29,7 @@ export default function PageClient({ graphData, initialNodeId }: Props) {
     initialNodeId ? `node:${initialNodeId}` : "graph"
   );
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [explorerOpen, setExplorerOpen] = useState(false);
   const [focusNodeId, setFocusNodeId] = useState<string | null>(null);
 
   const activeTab = useMemo(
@@ -74,12 +76,15 @@ export default function PageClient({ graphData, initialNodeId }: Props) {
     return () => window.removeEventListener("popstate", handlePopState);
   }, []);
 
-  // ⌘K / Ctrl+K keyboard shortcut
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === "k") {
         e.preventDefault();
         setPaletteOpen((v) => !v);
+      }
+      if ((e.metaKey || e.ctrlKey) && e.key === "b") {
+        e.preventDefault();
+        setExplorerOpen((v) => !v);
       }
     };
     window.addEventListener("keydown", handleKeyDown);
@@ -132,6 +137,7 @@ export default function PageClient({ graphData, initialNodeId }: Props) {
 
   const showGraph = activeTab.type === "graph";
   const openSearch = useCallback(() => setPaletteOpen(true), []);
+  const toggleExplorer = useCallback(() => setExplorerOpen((v) => !v), []);
 
   return (
     <div className="relative w-screen h-screen overflow-hidden">
@@ -147,7 +153,7 @@ export default function PageClient({ graphData, initialNodeId }: Props) {
       {activeNode && !showGraph && (
         <div className="absolute inset-0 bg-background overflow-hidden">
           <div className="flex flex-col h-full">
-            <Navbar onLogoClick={() => setActiveTabId("graph")} onSearchClick={openSearch} />
+            <Navbar onLogoClick={() => setActiveTabId("graph")} onSearchClick={openSearch} onExplorerToggle={toggleExplorer} explorerOpen={explorerOpen} />
             {hasNodeTabs && (
               <TabBar
                 tabs={tabs}
@@ -171,7 +177,7 @@ export default function PageClient({ graphData, initialNodeId }: Props) {
 
       {showGraph && (
         <div className="absolute top-0 left-0 right-0 z-10">
-          <Navbar onLogoClick={() => setActiveTabId("graph")} onSearchClick={openSearch} />
+          <Navbar onLogoClick={() => setActiveTabId("graph")} onSearchClick={openSearch} onExplorerToggle={toggleExplorer} explorerOpen={explorerOpen} />
           {hasNodeTabs && (
             <TabBar
               tabs={tabs}
@@ -183,6 +189,13 @@ export default function PageClient({ graphData, initialNodeId }: Props) {
           )}
         </div>
       )}
+
+      <ExplorerPanel
+        nodes={graphData.nodes}
+        open={explorerOpen}
+        onClose={() => setExplorerOpen(false)}
+        onNodeSelect={handleNodeClick}
+      />
 
       <CommandPalette
         nodes={graphData.nodes}

--- a/lib/paths.ts
+++ b/lib/paths.ts
@@ -1,0 +1,118 @@
+export interface PathNode {
+  id: string;
+  hook: string;
+}
+
+export interface ReadingPath {
+  id: string;
+  title: string;
+  description: string;
+  nodes: PathNode[];
+}
+
+export const READING_PATHS: ReadingPath[] = [
+  {
+    id: "genesis",
+    title: "Genesis",
+    description: "Start with the proven — six declassified operations that show the pattern",
+    nodes: [
+      { id: "operation-northwoods", hook: "A signed Pentagon plan to stage attacks on Americans — declassified, real, and rejected by one man" },
+      { id: "mkultra", hook: "Now that you know they'd plan false flags, learn what they actually did — 20 years of mind control experiments on unwitting citizens" },
+      { id: "operation-paperclip", hook: "MKUltra's methods came from somewhere — 1,600 Nazi scientists smuggled into America with sanitized records" },
+      { id: "cointelpro", hook: "It wasn't just the CIA — the FBI ran its own war against civil rights leaders, antiwar activists, and American citizens" },
+      { id: "operation-mockingbird", hook: "They did all this in secret because they controlled the story — CIA assets embedded in every major newsroom" },
+      { id: "cia-drugs", hook: "The pattern complete: the same agency that controlled minds and media also ran cocaine through American cities" },
+    ],
+  },
+  {
+    id: "the-architecture",
+    title: "The Architecture",
+    description: "You've seen what they did — now understand how the machine actually works",
+    nodes: [
+      { id: "control-systems", hook: "Before going deeper, learn the framework — how invisible systems shape what entire populations think and never question" },
+      { id: "counterculture-psyop", hook: "Even rebellion can be manufactured — how the 1960s counterculture was steered by the same agencies you just read about" },
+      { id: "deep-state", hook: "These operations survived every election because the real government is permanent — the bureaucracy behind the elected faces" },
+      { id: "shadow-elite", hook: "Someone runs the deep state — the network of families, funds, and foundations that sit above governments" },
+      { id: "federal-reserve", hook: "Follow the money — a private institution that controls the dollar, created in a secret meeting on Jekyll Island" },
+      { id: "mass-surveillance", hook: "Money gives them power, surveillance gives them knowledge — PRISM, Five Eyes, and the end of privacy" },
+      { id: "bilderberg", hook: "Where do they coordinate? Annual closed-door meetings of 130 of the world's most powerful people, no press allowed" },
+      { id: "bohemian-grove", hook: "Where do they socialize? A private campground where presidents and CEOs perform rituals before a 40-foot owl" },
+    ],
+  },
+  {
+    id: "the-hidden-hand",
+    title: "The Hidden Hand",
+    description: "The networks behind the networks — secret societies from the Templars to today",
+    nodes: [
+      { id: "secret-societies", hook: "Power has always organized in the dark — from mystery schools in Egypt to boardrooms in Manhattan" },
+      { id: "knights-templar", hook: "The original template: a military order that became the richest organization in Europe, then was destroyed in a single day" },
+      { id: "holy-grail", hook: "What were the Templars really guarding? The Grail isn't a cup — it might be a bloodline, a secret, or a technology" },
+      { id: "hermetic-tradition", hook: "The philosophy that runs beneath all secret societies — 'as above, so below' and the hidden structure of reality" },
+      { id: "freemasonry", hook: "The network that survived the Templars — from cathedral builders to the men who designed Washington D.C." },
+      { id: "sacred-geometry", hook: "The hidden language encoded in temples, cathedrals, and corporate logos — mathematics as the signature of the initiated" },
+      { id: "illuminati", hook: "Founded in 1776, suppressed in 1785, allegedly still operating — the conspiracy that spawned all other conspiracies" },
+      { id: "new-world-order", hook: "The alleged endgame of every secret society — a single world government, one currency, total control" },
+      { id: "great-reset", hook: "The NWO rebranded for the 21st century — the World Economic Forum's published plan for restructuring global civilization" },
+    ],
+  },
+  {
+    id: "shattered-history",
+    title: "Shattered History",
+    description: "The events that broke public trust — each one changed the rules",
+    nodes: [
+      { id: "jfk", hook: "The assassination that broke America's trust in its government — and the investigation that made it worse" },
+      { id: "marilyn-monroe", hook: "She knew the Kennedys, she knew too much, and she died the way inconvenient people die around power" },
+      { id: "moon-landing", hook: "Von Braun's Nazi rocket reached the Moon — but did the cameras? The hoax theory and why millions still doubt" },
+      { id: "nine-eleven", hook: "The day that rewrote every rule — the Patriot Act, endless war, and questions that still have no answers" },
+      { id: "epstein", hook: "A convicted pedophile with ties to presidents, princes, and intelligence agencies — the blackmail operation hiding in plain sight" },
+      { id: "covid-lab-leak", hook: "The question they called a conspiracy theory in 2020 and a legitimate hypothesis by 2023" },
+      { id: "dead-internet", hook: "What if most of what you read online isn't written by humans anymore?" },
+      { id: "qanon", hook: "When conspiracy theories become a political movement — how 'trust the plan' captured millions" },
+    ],
+  },
+  {
+    id: "forbidden-science",
+    title: "Forbidden Science",
+    description: "Suppressed technology, secret weapons, and the science they don't teach",
+    nodes: [
+      { id: "tesla-suppressed-tech", hook: "The genius who lit the world — then the FBI seized his papers and his name was erased from textbooks" },
+      { id: "philadelphia-experiment", hook: "The Navy allegedly made a ship invisible in 1943 — the sailors who survived were never the same" },
+      { id: "haarp", hook: "180 antennas in Alaska that can heat the ionosphere — weather research or weather weapon?" },
+      { id: "chemtrails", hook: "The government has confirmed it sprayed cities with chemicals in secret — the question is whether they stopped" },
+      { id: "big-pharma", hook: "The industry that pays the largest criminal fines in history and still writes your doctor's prescriptions" },
+      { id: "aids-bioweapon", hook: "Fort Detrick, the same lab that weaponized anthrax, was researching retroviruses when HIV appeared" },
+      { id: "breakaway-civilization", hook: "What if 80 years of black-budget technology created a civilization so advanced it effectively left the rest of us behind?" },
+    ],
+  },
+  {
+    id: "lost-worlds",
+    title: "Lost Worlds",
+    description: "Before recorded history — the evidence that humanity is far older than we're told",
+    nodes: [
+      { id: "ancient-civilizations", hook: "The textbook says civilization began 5,000 years ago — the evidence says the textbook is wrong" },
+      { id: "gobekli-tepe", hook: "A 12,000-year-old temple complex built by people who supposedly couldn't farm yet" },
+      { id: "megaliths", hook: "Stones weighing 1,000 tons, cut with laser precision, moved across continents — with no explanation of how" },
+      { id: "tartaria", hook: "A civilization that appears on maps for centuries, then vanishes from history overnight" },
+      { id: "atlantis", hook: "Plato called it history, not myth — a civilization that preceded all others and was destroyed in a single day" },
+      { id: "bermuda-triangle", hook: "Ships vanish, compasses spin, pilots disappear mid-transmission — and the Navy says it's nothing" },
+      { id: "ancient-astronauts", hook: "Every ancient culture describes gods who came from the sky, taught them civilization, and left — what if they meant it literally?" },
+      { id: "nibiru", hook: "Zecharia Sitchin found a planet in Sumerian texts that modern astronomy can't account for" },
+      { id: "hollow-earth", hook: "Admiral Byrd said he flew into the Earth and found a green world inside — his diary was classified" },
+    ],
+  },
+  {
+    id: "the-cosmic-question",
+    title: "The Cosmic Question",
+    description: "UFOs, consciousness, and the deepest question — what is reality?",
+    nodes: [
+      { id: "roswell", hook: "Something crashed in New Mexico in 1947 — the military said it was a weather balloon, then changed the story three times" },
+      { id: "area-51", hook: "The base the government denied existed until 2013 — what else are they testing in the Nevada desert?" },
+      { id: "ufos", hook: "The Pentagon admitted UAPs are real in 2017 — after 70 years of saying they weren't" },
+      { id: "fermi-paradox", hook: "The universe is 13.8 billion years old with trillions of planets — so where is everybody?" },
+      { id: "simulation-hypothesis", hook: "Physicists and philosophers are seriously asking: what if reality is computed?" },
+      { id: "consciousness", hook: "Science can't explain why you experience anything at all — the hard problem that won't go away" },
+      { id: "altered-states", hook: "Meditation, psychedelics, near-death — what these states reveal about the nature of the mind" },
+      { id: "mandela-effect", hook: "Millions of people share the same false memories — glitch in the matrix or something stranger?" },
+    ],
+  },
+];


### PR DESCRIPTION
introducing a slide-out drawer (toggle with the navbar button or Cmd+B) with a frosted glass aesthetic that provides two ways to navigate the graph:

- paths — 7 curated reading paths that guide newcomers through the material in a logical order, where each node builds on the previous one. No duplicate nodes across paths. Paths: `Genesis`, `The Architecture`, `The Hidden Hand`, `Shattered History`, `Forbidden Science`, `Lost Worlds`, `The Cosmic Question`.
- browse — traditional category tree with all nodes grouped, sorted by connection count, with a search
filter.

as bonus feature to complete the exploration drawer added ReadNext which is a a card at the bottom of every node article that suggests the next node in the reading path. When you finish the last node in a path, it suggests the first node of the next path — so you can read through all 7 paths as one continuous journey.
